### PR TITLE
Return both manifest and digest for pull manifest (#2034)

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
@@ -44,7 +44,7 @@ public class BlobCheckerIntegrationTest {
             .setAllowInsecureRegistries(true)
             .newRegistryClient();
     V22ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class);
+        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
     DescriptorDigest blobDigest = manifestTemplate.getLayers().get(0).getDigest();
 
     Assert.assertEquals(blobDigest, registryClient.checkBlob(blobDigest).get().getDigest());

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
@@ -52,7 +52,7 @@ public class BlobPullerIntegrationTest {
             .setAllowInsecureRegistries(true)
             .newRegistryClient();
     V21ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V21ManifestTemplate.class);
+        registryClient.pullManifest("latest", V21ManifestTemplate.class).getManifest();
 
     DescriptorDigest realDigest = manifestTemplate.getLayerDigests().get(0);
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPusherIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPusherIntegrationTest.java
@@ -47,7 +47,7 @@ public class ManifestPusherIntegrationTest {
   public void testPush_missingBlobs() throws IOException, RegistryException {
     RegistryClient registryClient =
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/java").newRegistryClient();
-    ManifestTemplate manifestTemplate = registryClient.pullManifest("latest");
+    ManifestTemplate manifestTemplate = registryClient.pullManifest("latest").getManifest();
 
     registryClient =
         RegistryClient.factory(EventHandlers.NONE, "localhost:5000", "busybox")
@@ -101,7 +101,7 @@ public class ManifestPusherIntegrationTest {
 
     // Pulls the manifest.
     V22ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class);
+        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
     Assert.assertEquals(1, manifestTemplate.getLayers().size());
     Assert.assertEquals(testLayerBlobDigest, manifestTemplate.getLayers().get(0).getDigest());
     Assert.assertNotNull(manifestTemplate.getContainerConfiguration());
@@ -111,7 +111,9 @@ public class ManifestPusherIntegrationTest {
 
     // Pulls the manifest by digest.
     V22ManifestTemplate manifestTemplateByDigest =
-        registryClient.pullManifest(imageDigest.toString(), V22ManifestTemplate.class);
+        registryClient
+            .pullManifest(imageDigest.toString(), V22ManifestTemplate.class)
+            .getManifest();
     Assert.assertEquals(
         Digests.computeJsonDigest(manifestTemplate),
         Digests.computeJsonDigest(manifestTemplateByDigest));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ManifestAndDigest.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ManifestAndDigest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.image.json;
+
+import com.google.cloud.tools.jib.api.DescriptorDigest;
+
+/** Stores a manifest and digest */
+public class ManifestAndDigest<T extends ManifestTemplate> {
+
+  private final T manifest;
+  private final DescriptorDigest digest;
+
+  public ManifestAndDigest(T manifest, DescriptorDigest digest) {
+    this.manifest = manifest;
+    this.digest = digest;
+  }
+
+  /**
+   * Gets the manifest.
+   *
+   * @return the manifest
+   */
+  public T getManifest() {
+    return manifest;
+  }
+
+  /**
+   * Gets the digest.
+   *
+   * @return the digest
+   */
+  public DescriptorDigest getDigest() {
+    return digest;
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestPuller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestPuller.java
@@ -19,8 +19,11 @@ package com.google.cloud.tools.jib.registry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.client.http.HttpMethods;
+import com.google.cloud.tools.jib.api.DescriptorDigest;
+import com.google.cloud.tools.jib.hash.Digests;
 import com.google.cloud.tools.jib.http.BlobHttpContent;
 import com.google.cloud.tools.jib.http.Response;
+import com.google.cloud.tools.jib.image.json.ManifestAndDigest;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
 import com.google.cloud.tools.jib.image.json.UnknownManifestFormatException;
@@ -28,9 +31,8 @@ import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestListTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
-import com.google.common.io.CharStreams;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -40,7 +42,8 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 /** Pulls an image's manifest. */
-class ManifestPuller<T extends ManifestTemplate> implements RegistryEndpointProvider<T> {
+class ManifestPuller<T extends ManifestTemplate>
+    implements RegistryEndpointProvider<ManifestAndDigest<T>> {
 
   private final RegistryEndpointRequestProperties registryEndpointRequestProperties;
   private final String imageTag;
@@ -85,12 +88,16 @@ class ManifestPuller<T extends ManifestTemplate> implements RegistryEndpointProv
         V21ManifestTemplate.MEDIA_TYPE);
   }
 
-  /** Parses the response body into a {@link ManifestTemplate}. */
+  /** Parses the response body into a {@link ManifestAndDigest}. */
   @Override
-  public T handleResponse(Response response) throws IOException, UnknownManifestFormatException {
-    String jsonString =
-        CharStreams.toString(new InputStreamReader(response.getBody(), StandardCharsets.UTF_8));
-    return getManifestTemplateFromJson(jsonString);
+  public ManifestAndDigest<T> handleResponse(Response response)
+      throws IOException, UnknownManifestFormatException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DescriptorDigest digest =
+        Digests.computeDigest(response.getBody(), byteArrayOutputStream).getDigest();
+    String jsonString = byteArrayOutputStream.toString(StandardCharsets.UTF_8.name());
+    T manifestTemplate = getManifestTemplateFromJson(jsonString);
+    return new ManifestAndDigest<>(manifestTemplate, digest);
   }
 
   @Override

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -30,6 +30,7 @@ import com.google.cloud.tools.jib.global.JibSystemProperties;
 import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.http.Response;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
+import com.google.cloud.tools.jib.image.json.ManifestAndDigest;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
@@ -171,6 +172,7 @@ public class RegistryClient {
    */
   @JsonIgnoreProperties(ignoreUnknown = true)
   private static class TokenPayloadTemplate implements JsonTemplate {
+
     @Nullable private List<AccessClaim> access;
   }
 
@@ -181,6 +183,7 @@ public class RegistryClient {
    */
   @JsonIgnoreProperties(ignoreUnknown = true)
   private static class AccessClaim implements JsonTemplate {
+
     @Nullable private String type;
     @Nullable private String name;
     @Nullable private List<String> actions;
@@ -279,25 +282,26 @@ public class RegistryClient {
   }
 
   /**
-   * Pulls the image manifest for a specific tag.
+   * Pulls the image manifest and digest for a specific tag.
    *
    * @param <T> child type of ManifestTemplate
    * @param imageTag the tag to pull on
    * @param manifestTemplateClass the specific version of manifest template to pull, or {@link
    *     ManifestTemplate} to pull predefined subclasses; see: {@link
    *     ManifestPuller#handleResponse(Response)}
-   * @return the manifest template
+   * @return the {@link ManifestAndDigest}
    * @throws IOException if communicating with the endpoint fails
    * @throws RegistryException if communicating with the endpoint fails
    */
-  public <T extends ManifestTemplate> T pullManifest(
+  public <T extends ManifestTemplate> ManifestAndDigest<T> pullManifest(
       String imageTag, Class<T> manifestTemplateClass) throws IOException, RegistryException {
     ManifestPuller<T> manifestPuller =
         new ManifestPuller<>(registryEndpointRequestProperties, imageTag, manifestTemplateClass);
     return callRegistryEndpoint(manifestPuller);
   }
 
-  public ManifestTemplate pullManifest(String imageTag) throws IOException, RegistryException {
+  public ManifestAndDigest<ManifestTemplate> pullManifest(String imageTag)
+      throws IOException, RegistryException {
     return pullManifest(imageTag, ManifestTemplate.class);
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
@@ -16,7 +16,10 @@
 
 package com.google.cloud.tools.jib.registry;
 
+import com.google.cloud.tools.jib.api.DescriptorDigest;
+import com.google.cloud.tools.jib.hash.Digests;
 import com.google.cloud.tools.jib.http.Response;
+import com.google.cloud.tools.jib.image.json.ManifestAndDigest;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
 import com.google.cloud.tools.jib.image.json.UnknownManifestFormatException;
@@ -52,13 +55,13 @@ public class ManifestPullerTest {
     return new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
   }
 
-  @Mock private Response mockResponse;
-
   private final RegistryEndpointRequestProperties fakeRegistryEndpointRequestProperties =
       new RegistryEndpointRequestProperties("someServerUrl", "someImageName");
   private final ManifestPuller<ManifestTemplate> testManifestPuller =
       new ManifestPuller<>(
           fakeRegistryEndpointRequestProperties, "test-image-tag", ManifestTemplate.class);
+
+  @Mock private Response mockResponse;
 
   @Test
   public void testHandleResponse_v21()
@@ -66,13 +69,18 @@ public class ManifestPullerTest {
     Path v21ManifestFile = Paths.get(Resources.getResource("core/json/v21manifest.json").toURI());
     InputStream v21Manifest = new ByteArrayInputStream(Files.readAllBytes(v21ManifestFile));
 
+    DescriptorDigest expectedDigest = Digests.computeDigest(v21Manifest).getDigest();
+    v21Manifest.reset();
+
     Mockito.when(mockResponse.getBody()).thenReturn(v21Manifest);
-    ManifestTemplate manifestTemplate =
+    ManifestAndDigest manifestAndDigest =
         new ManifestPuller<>(
                 fakeRegistryEndpointRequestProperties, "test-image-tag", V21ManifestTemplate.class)
             .handleResponse(mockResponse);
 
-    Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V21ManifestTemplate.class));
+    Assert.assertThat(
+        manifestAndDigest.getManifest(), CoreMatchers.instanceOf(V21ManifestTemplate.class));
+    Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
 
   @Test
@@ -81,13 +89,18 @@ public class ManifestPullerTest {
     Path v22ManifestFile = Paths.get(Resources.getResource("core/json/v22manifest.json").toURI());
     InputStream v22Manifest = new ByteArrayInputStream(Files.readAllBytes(v22ManifestFile));
 
+    DescriptorDigest expectedDigest = Digests.computeDigest(v22Manifest).getDigest();
+    v22Manifest.reset();
+
     Mockito.when(mockResponse.getBody()).thenReturn(v22Manifest);
-    ManifestTemplate manifestTemplate =
+    ManifestAndDigest manifestAndDigest =
         new ManifestPuller<>(
                 fakeRegistryEndpointRequestProperties, "test-image-tag", V22ManifestTemplate.class)
             .handleResponse(mockResponse);
 
-    Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestTemplate.class));
+    Assert.assertThat(
+        manifestAndDigest.getManifest(), CoreMatchers.instanceOf(V22ManifestTemplate.class));
+    Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
 
   @Test
@@ -114,15 +127,19 @@ public class ManifestPullerTest {
     Path v22ManifestListFile =
         Paths.get(Resources.getResource("core/json/v22manifest_list.json").toURI());
     InputStream v22ManifestList = new ByteArrayInputStream(Files.readAllBytes(v22ManifestListFile));
+    DescriptorDigest expectedDigest = Digests.computeDigest(v22ManifestList).getDigest();
+    v22ManifestList.reset();
 
     Mockito.when(mockResponse.getBody()).thenReturn(v22ManifestList);
-    ManifestTemplate manifestTemplate =
+    ManifestAndDigest manifestAndDigest =
         new ManifestPuller<>(
                 fakeRegistryEndpointRequestProperties, "test-image-tag", ManifestTemplate.class)
             .handleResponse(mockResponse);
+    ManifestTemplate manifestTemplate = manifestAndDigest.getManifest();
 
     Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
     Assert.assertTrue(((V22ManifestListTemplate) manifestTemplate).getManifests().size() > 0);
+    Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
 
   @Test
@@ -132,16 +149,21 @@ public class ManifestPullerTest {
         Paths.get(Resources.getResource("core/json/v22manifest_list.json").toURI());
     InputStream v22ManifestList = new ByteArrayInputStream(Files.readAllBytes(v22ManifestListFile));
 
+    DescriptorDigest expectedDigest = Digests.computeDigest(v22ManifestList).getDigest();
+    v22ManifestList.reset();
+
     Mockito.when(mockResponse.getBody()).thenReturn(v22ManifestList);
-    V22ManifestListTemplate manifestTemplate =
+    ManifestAndDigest<V22ManifestListTemplate> manifestAndDigest =
         new ManifestPuller<>(
                 fakeRegistryEndpointRequestProperties,
                 "test-image-tag",
                 V22ManifestListTemplate.class)
             .handleResponse(mockResponse);
+    V22ManifestListTemplate manifestTemplate = manifestAndDigest.getManifest();
 
     Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
     Assert.assertTrue(manifestTemplate.getManifests().size() > 0);
+    Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
 
   @Test


### PR DESCRIPTION
Pull manifest now will return the image digest along with the manifest of the base image. This will be helpful for logging the base image digest #1884.